### PR TITLE
fix: name in body needs to be a string

### DIFF
--- a/lessons/08-route-handlers/A-validating-inputs.md
+++ b/lessons/08-route-handlers/A-validating-inputs.md
@@ -13,7 +13,7 @@ For any route, you want to add input validations:
 ```ts
 import { body, validationResult } from "express-validator";
 
-app.post("/product", body("name"), (req, res) => {
+app.post("/product", body("name").isString(), (req, res) => {
   const errors = validationResult(req);
 
   if (!errors.isEmpty()) {


### PR DESCRIPTION
The request was hanging unless we explicitly mention `name` on body needs to be a string. I guess default value of `name` on `req.body` will be `undefined` & unless we restrict type, `express-validator` won't consider it as an error.